### PR TITLE
Minor corrections to remove deprecation warnings and improve checking for empty config dict values

### DIFF
--- a/src/lib/rf_data_recording_api_def.py
+++ b/src/lib/rf_data_recording_api_def.py
@@ -392,7 +392,7 @@ class RFDataRecorderAPI:
             return variations_product
 
         # get hW info of TX Stations
-        num_tx_usrps = int(general_config["num_tx_usrps"])
+        num_tx_usrps = int(general_config["num_tx_usrps"].item())
         if num_tx_usrps > 0:
             # if Tx station is USRP
             variations_product = get_usrp_mboard_info(
@@ -403,7 +403,7 @@ class RFDataRecorderAPI:
                     num_tx_usrps, RFDataRecorderAPI.RFmode[0], variations_product)
 
         # get hW info of RX Stations
-        num_rx_usrps = int(general_config["num_rx_usrps"])
+        num_rx_usrps = int(general_config["num_rx_usrps"].item())
         if num_rx_usrps > 0:
             # if Rx station is USRP
             variations_product = get_usrp_mboard_info(

--- a/src/lib/rf_data_recording_config_interface.py
+++ b/src/lib/rf_data_recording_config_interface.py
@@ -48,9 +48,9 @@ def read_config_files(rf_data_acq_config_file: str):
 
 # Check whether dict of config is filled at all
 def check_config_dict(config_dict):
-    if bool(config_dict):
+    if config_dict:
         for key, value in config_dict.items():
-            if not value:
+            if value is None or value == "":
                 raise Exception(f"Config field '{key}' is not filled!")
 
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-rf-data-recording-api/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- use .item() on pandas.Series to avoid deprecation warnings during conversion to int
- test for None and empty string instead of False value when checking config dict

### Why should this Pull Request be merged?

- allow for config dict entries with values 0, 0.0, False

### What testing has been done?

Limited testing only