### PR TITLE
Implement support for B2xx as transmitter

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,12 @@
 Changelog - NI RF Data Recording API
 
 ======================
+v1.4.0        07.07.26
+======================
+
+- added B2xx as transmitter using multi usrp api
+
+======================
 v1.3.0        06.06.25
 ======================
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,10 +1,10 @@
 Changelog - NI RF Data Recording API
 
 ======================
-v1.4.0        07.07.26
+v1.4.0        10.07.26
 ======================
 
-- added B2xx as transmitter using multi usrp api
+- support B2xx as transmitter using MultiUSRP API
 
 ======================
 v1.3.0        06.06.25

--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ To use the NI RF Data Recording API, you need at least one NI RF USRP device (fo
 - [NI USRP X310](https://www.ettus.com/all-products/x310-kit/) ([X300/X310 Getting Started Guides](https://kb.ettus.com/X300/X310_Getting_Started_Guides))
 - [NI USRP X410](https://www.ettus.com/all-products/usrp-x410/) ([X410 Getting Started Guides](https://kb.ettus.com/USRP_X410_Getting_Started_Guide))
 - [NI USRP B210](https://www.ettus.com/all-products/ub210-kit/) ([B2xx Getting Started Guides](https://kb.ettus.com/B200/B210/B200mini/B205mini_Getting_Started_Guides))
-  - Note: RX only
 
 The devices should be connected to single or different host computers based on the API operation mode and the investigated application. The following figure shows the setup of three Tx stations and one Rx Station.   
 ![Hardware](docs/figures/rf_data_recording_setup.png "Hardware Configuration")
@@ -503,9 +502,10 @@ Note: Maintenance of this Git repository will be done on best effort basis.
 ---
 
 ## Known Issues and Limitations
--	Tested on both X310 and X410 USRP only
+-	Tested on B2xx, X310 and X410 USRP as transmitter
 -   For the mmWave support, tested on BBox One 5G and BBox Lite 5G as the beam former, UD Box 5G as the UDC based on the one Tx station and one Rx station. 
 -   Currently, the software mmWave driver version used in the example has restrictions on the calling path, i.e., the relative path cannot be changed, which depends on the updates and iterations by the driver developer.
+-   For B2xx as transmitter, it can limit to 4G and 5G tdms waveform only used. It will not work for Wifi waveform.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -502,11 +502,10 @@ Note: Maintenance of this Git repository will be done on best effort basis.
 ---
 
 ## Known Issues and Limitations
--	Tested on  X310 and X410 as transmitter only.
--   B210, B205mini, B206mini were tested as transmitter as well as receiver.
--   For the mmWave support, tested on BBox One 5G and BBox Lite 5G as the beam former, UD Box 5G as the UDC based on the one Tx station and one Rx station. 
--   Currently, the software mmWave driver version used in the example has restrictions on the calling path, i.e., the relative path cannot be changed, which depends on the updates and iterations by the driver developer.
--   For B2xx as transmitter, additional performance limitations might apply depending on signal bandwidth and host capabilities.
+- Tested on X310 and X410 USRP, as well as B210, B205mini and B206mini.
+- For the mmWave support, tested on BBox One 5G and BBox Lite 5G as the beam former, UD Box 5G as the UDC based on the one Tx station and one Rx station. 
+- Currently, the software mmWave driver version used in the example has restrictions on the calling path, i.e., the relative path cannot be changed, which depends on the updates and iterations by the driver developer.
+- For B2xx as transmitter, additional performance limitations might apply depending on signal bandwidth and host capabilities.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![NI Logo](docs/figures/NI_NEU_API_landing_page.png "NI & NEU API Logo")
 
-# NI RF Data Recording API v1.3.0
+# NI RF Data Recording API v1.4.0
 
 Welcome to RF Data Recording API! The RF Data Recording API is the free and open-source Python-based API to record Real-World RF data sets in an easy and automated way.
 
@@ -502,10 +502,11 @@ Note: Maintenance of this Git repository will be done on best effort basis.
 ---
 
 ## Known Issues and Limitations
--	Tested on B2xx, X310 and X410 USRP as transmitter
+-	Tested on  X310 and X410 as transmitter only.
+-   B210, B205mini, B206mini were tested as transmitter as well as receiver.
 -   For the mmWave support, tested on BBox One 5G and BBox Lite 5G as the beam former, UD Box 5G as the UDC based on the one Tx station and one Rx station. 
 -   Currently, the software mmWave driver version used in the example has restrictions on the calling path, i.e., the relative path cannot be changed, which depends on the updates and iterations by the driver developer.
--   For B2xx as transmitter, it can limit to 4G and 5G tdms waveform only used. It will not work for Wifi waveform.
+-   For B2xx as transmitter, additional performance limitations might apply depending on signal bandwidth and host capabilities.
 
 ---
 

--- a/examples/spectrum_sensing/config/config_spectrum_sensing_1Tx1_1Rx.json
+++ b/examples/spectrum_sensing/config/config_spectrum_sensing_1Tx1_1Rx.json
@@ -77,7 +77,7 @@
     },
     "transmitters_config": [
       {
-        "RFmode": "Tx", "type": "x4xx", "name": "jan-x4xx-323F762",
+        "RFmode": "Tx", "type": "b200", "name": "B206i",
         "Parameters": {
           "freq":           {"SeqType": "single",    "Values": 3.6e9},
           "lo_offset":      {"SeqType": "single",   "Values": -20.0e6},
@@ -105,7 +105,7 @@
       "tx_duc_id":        {"SeqType": "list",     "Values": [0]}},
     "receivers_config": [
       {
-        "RFmode": "Rx", "type": "b200",
+        "RFmode": "Rx", "type": "b200", "serial": "345D72B",
         "recv_frame_size": 16360, "num_recv_frames": 32,
         "Parameters": {
             "freq":         {"SeqType": "single",    "Values": 3.6e9},

--- a/examples/spectrum_sensing/config/config_spectrum_sensing_1Tx1_1Rx.json
+++ b/examples/spectrum_sensing/config/config_spectrum_sensing_1Tx1_1Rx.json
@@ -77,7 +77,7 @@
     },
     "transmitters_config": [
       {
-        "RFmode": "Tx", "type": "b200", "name": "B206i",
+        "RFmode": "Tx", "type": "x4xx",
         "Parameters": {
           "freq":           {"SeqType": "single",    "Values": 3.6e9},
           "lo_offset":      {"SeqType": "single",   "Values": -20.0e6},
@@ -105,7 +105,7 @@
       "tx_duc_id":        {"SeqType": "list",     "Values": [0]}},
     "receivers_config": [
       {
-        "RFmode": "Rx", "type": "b200", "serial": "345D72B",
+        "RFmode": "Rx", "type": "b200",
         "recv_frame_size": 16360, "num_recv_frames": 32,
         "Parameters": {
             "freq":         {"SeqType": "single",    "Values": 3.6e9},

--- a/examples/spectrum_sensing/config/config_spectrum_sensing_1Tx2_1Rx.json
+++ b/examples/spectrum_sensing/config/config_spectrum_sensing_1Tx2_1Rx.json
@@ -77,7 +77,7 @@
     },
     "transmitters_config": [
       {
-        "RFmode": "Tx", "type": "x4xx", "name": "jan-x4xx-323F762",
+        "RFmode": "Tx", "type": "x4xx",
         "Parameters": {
           "freq":           {"SeqType": "single",    "Values": 3.6e9},
           "lo_offset":      {"SeqType": "single",   "Values": 20.0e6},

--- a/src/lib/run_rf_replay_data_transmitter.py
+++ b/src/lib/run_rf_replay_data_transmitter.py
@@ -42,11 +42,11 @@ def rf_replay_data_transmitter(args):
     
     print("HW TYPE =", args.hw_type)
     if "B" in str(args.hw_type).upper():
-        return rf_b2xx_data_transmitter(args)
+        return rf_multiusrp_data_transmitter(args)
     else:
         return rf_replay_data_transmitter_rfnoc(args)
 
-#siddhant_code_change
+#Code to handle all USRP having FPGA access so as to use Replay block feature
 def rf_replay_data_transmitter_rfnoc(args):
     """
     Run Tx waveform playback
@@ -324,8 +324,8 @@ def rf_replay_data_transmitter_rfnoc(args):
     print("Letting device settle...")
     time.sleep(0.05)  # sleep for 50ms
 
-#siddhant_code_change
-def rf_b2xx_data_transmitter(args):
+#Code to handle all B-series usrp having no access to FPGA and use MultiUSRP API for Tx waveform playback
+def rf_multiusrp_data_transmitter(args):
     """
     Run Tx waveform playback using MultiUSRP (B2xx devices)
     """

--- a/src/lib/run_rf_replay_data_transmitter.py
+++ b/src/lib/run_rf_replay_data_transmitter.py
@@ -330,187 +330,128 @@ def rf_multiusrp_data_transmitter(args):
     Run Tx waveform playback using MultiUSRP (B2xx devices)
     """
 
-    # ============================================================
-    # Run mmWave devices first if exist
-    # ============================================================
+    # Run mmwave devices first if exist
     if args.enable_mmwave:
         mmwave_up_down_converter_parameters = args.mmwave_up_down_converter_parameters
         mmwave_antenna_array_parameters = args.mmwave_antenna_array_parameters
-        run_mmWave_device.start_ud_execution(
-            mmwave_up_down_converter_parameters
-        )
-        run_mmWave_device.start_beamformer(
-            mmwave_antenna_array_parameters
-        )
+
+        run_mmWave_device.start_ud_execution(mmwave_up_down_converter_parameters)
+        run_mmWave_device.start_beamformer(mmwave_antenna_array_parameters)
 
     print("")
-    print("===================================")
     print("Using B2xx MultiUSRP TX Backend")
-    print("===================================")
 
-    # ============================================================
+    # ************************************************************************
     # Create USRP
-    # ============================================================
+    # ************************************************************************
     print("Creating MultiUSRP with args:", args.args)
 
     usrp = uhd.usrp.MultiUSRP(args.args)
 
-    # ============================================================
-    # Load waveform
-    # ============================================================
+    # ************************************************************************
+    # Read waveform
+    # ************************************************************************
     print("")
     print("Reading waveform...")
 
     tx_rate = args.rate
 
     if args.waveform_format == "tdms":
-
-        tx_data_complex, waveform_IQ_rate = (
-            read_waveform_data_interface.read_waveform_data_tdms(
-                args.waveform_path,
-                args.waveform_file_name
-            )
+        tx_data_complex, waveform_IQ_rate = read_waveform_data_interface.read_waveform_data_tdms(
+            args.waveform_path,
+            args.waveform_file_name,
         )
 
-        tx_rate = waveform_IQ_rate
+        if args.rate != waveform_IQ_rate:
+            print("Note:The IQ Rate based on TDMS Waveform property should be: ", waveform_IQ_rate)
 
-        print(
-            f"TDMS IQ Rate : "
-            f"{tx_rate/1e6:.3f} Msps"
-        )
+        print(f"TDMS IQ Rate : {tx_rate / 1e6:.3f} Msps")
 
     elif args.waveform_format == "matlab_ieee":
-
-        tx_data_complex = (
-            read_waveform_data_interface.read_waveform_data_matlab_ieee(
-                args.waveform_path,
-                args.waveform_file_name
-            )
+        tx_data_complex = read_waveform_data_interface.read_waveform_data_matlab_ieee(
+            args.waveform_path,
+            args.waveform_file_name,
         )
 
     elif args.waveform_format == "matlab":
-
-        tx_data_complex = (
-            read_waveform_data_interface.read_waveform_data_matlab(
-                args.waveform_path,
-                args.waveform_file_name
-            )
+        tx_data_complex = read_waveform_data_interface.read_waveform_data_matlab(
+            args.waveform_path,
+            args.waveform_file_name,
         )
 
     else:
-        raise Exception(
-            "ERROR: Unknown or not supported waveform format."
-        )
+        raise Exception("ERROR: Unknown or not supported waveform format.")
 
     print("IQ Samples:", len(tx_data_complex))
 
-    # ============================================================
+    # ************************************************************************
     # Configure TX
-    # ============================================================
+    # ************************************************************************
+    print("")
+    print("Setting up TX...")
+
     try:
         usrp.set_clock_source(args.clock_reference)
     except Exception:
         pass
 
-    print(
-        f"Requesting TX Rate: "
-        f"{tx_rate/1e6:.3f} Msps"
-    )
-
+    print(f"Requesting TX Rate: {tx_rate / 1e6:.3f} Msps")
     usrp.set_tx_rate(tx_rate)
 
-    print(
-        f"Actual TX Rate: "
-        f"{usrp.get_tx_rate()/1e6:.3f} Msps"
-    )
+    print(f"Actual TX Rate: {usrp.get_tx_rate() / 1e6:.3f} Msps")
 
-    print(
-        f"Requesting TX Frequency: "
-        f"{args.freq/1e6:.3f} MHz"
-    )
+    print(f"Requesting TX Frequency: {args.freq / 1e6:.3f} MHz")
 
     if str2bool(args.enable_lo_offset):
-
-        tune_request = uhd.types.TuneRequest(
-            args.freq,
-            args.lo_offset
-        )
-
-        usrp.set_tx_freq(
-            tune_request,
-            args.radio_chan
-        )
-
+        tune_request = uhd.types.TuneRequest(args.freq, args.lo_offset)
+        usrp.set_tx_freq(tune_request, args.radio_chan)
     else:
-
-        usrp.set_tx_freq(
-            args.freq,
-            args.radio_chan
-        )
+        usrp.set_tx_freq(args.freq, args.radio_chan)
 
     try:
         print(
             f"Actual TX Frequency: "
-            f"{usrp.get_tx_freq(args.radio_chan)/1e6:.3f} MHz"
+            f"{usrp.get_tx_freq(args.radio_chan) / 1e6:.3f} MHz"
         )
     except Exception:
         pass
 
     print(f"Requesting TX Gain: {args.gain} dB")
 
-    usrp.set_tx_gain(
-        args.gain,
-        args.radio_chan
-    )
+    usrp.set_tx_gain(args.gain, args.radio_chan)
 
     try:
-        print(
-            f"Actual TX Gain: "
-            f"{usrp.get_tx_gain(args.radio_chan)} dB"
-        )
+        print(f"Actual TX Gain: {usrp.get_tx_gain(args.radio_chan)} dB")
     except Exception:
         pass
 
     try:
-
-        usrp.set_tx_bandwidth(
-            args.bandwidth,
-            args.radio_chan
-        )
+        usrp.set_tx_bandwidth(args.bandwidth, args.radio_chan)
 
         print(
             f"Actual TX Bandwidth: "
-            f"{usrp.get_tx_bandwidth(args.radio_chan)/1e6:.3f} MHz"
+            f"{usrp.get_tx_bandwidth(args.radio_chan) / 1e6:.3f} MHz"
         )
-
     except Exception:
         print("Bandwidth configuration skipped")
 
     try:
-
-        usrp.set_tx_antenna(
-            args.antenna,
-            args.radio_chan
-        )
+        usrp.set_tx_antenna(args.antenna, args.radio_chan)
 
         print(
             f"Actual TX Antenna: "
             f"{usrp.get_tx_antenna(args.radio_chan)}"
         )
-
     except Exception:
         print("Antenna configuration skipped")
 
-    time.sleep(0.1)
+    # Allow for some setup time
+    time.sleep(100e-3)
 
-    # ============================================================
-    # Repeat waveform
-    # same idea as your standalone script
-    # ============================================================
-    tx_data_complex = np.tile(
-        tx_data_complex,
-        50
-    )
+    # ************************************************************************
+    # Prepare waveform
+    # ************************************************************************
+    tx_data_complex = np.tile(tx_data_complex, 50)
 
     duration = len(tx_data_complex) / tx_rate
 
@@ -519,31 +460,23 @@ def rf_multiusrp_data_transmitter(args):
 
     tx_channels = [args.radio_chan]
 
-    # ============================================================
-    # Start RX acquisition
-    # ============================================================
+    # ************************************************************************
+    # Start continuous transmission
+    # ************************************************************************
     sync_settings.start_rx_data_acquisition_called = True
 
     print("")
     print("Starting Continuous Transmission")
 
     try:
-
         first_run = True
 
-        while not sync_settings.stop_tx_signal_called:
+        while sync_settings.stop_tx_signal_called == False:
 
             if first_run:
-
-                tx_start_time = (
-                    usrp.get_time_now()
-                    + uhd.types.TimeSpec(0.2)
-                )
-
+                tx_start_time = usrp.get_time_now() + uhd.types.TimeSpec(0.2)
                 first_run = False
-
             else:
-
                 tx_start_time = None
 
             usrp.send_waveform(
@@ -557,16 +490,14 @@ def rf_multiusrp_data_transmitter(args):
             )
 
     except Exception as ex:
-
         print("TX Error:", ex)
 
     print("Stopping transmission...")
 
-    # ============================================================
-    # mmWave cleanup
-    # ============================================================
+    # ************************************************************************
+    # Stop mmwave devices if exist
+    # ************************************************************************
     if args.enable_mmwave:
-
         run_mmWave_device.deinit_mmwave_device(
             mmwave_up_down_converter_parameters.serial_number
         )

--- a/src/lib/run_rf_replay_data_transmitter.py
+++ b/src/lib/run_rf_replay_data_transmitter.py
@@ -14,14 +14,10 @@ TX Waveform Playback
 #
 # Pre-requests: Install UHD with Python API enabled
 #
-import sys
-import signal
 import time
 import argparse
 import numpy as np
 import uhd
-from nptdms import TdmsFile
-import scipy.io
 
 # import other functions
 from lib import read_waveform_data_interface, run_mmWave_device
@@ -37,16 +33,21 @@ def str2bool(v):
         return False
     else:
         raise argparse.ArgumentTypeError("Boolean value expected.")
-#siddhant_code_change
+
+# Main TX waveform playback entry point.
 def rf_replay_data_transmitter(args):
+    """
+    Run Tx waveform playback based on USRP type.
     
+    If USRP is B-series (B210, B206, ...), use MultiUSRP API, else use RFNoC API
+    """
     print("HW TYPE =", args.hw_type)
     if "B" in str(args.hw_type).upper():
         return rf_multiusrp_data_transmitter(args)
     else:
         return rf_replay_data_transmitter_rfnoc(args)
 
-#Code to handle all USRP having FPGA access so as to use Replay block feature
+# Code to handle all USRP having FPGA access so as to use Replay block feature
 def rf_replay_data_transmitter_rfnoc(args):
     """
     Run Tx waveform playback
@@ -324,10 +325,10 @@ def rf_replay_data_transmitter_rfnoc(args):
     print("Letting device settle...")
     time.sleep(0.05)  # sleep for 50ms
 
-#Code to handle all B-series usrp having no access to FPGA and use MultiUSRP API for Tx waveform playback
+# Code to handle all B-series USRP having no access to FPGA and use MultiUSRP API instead
 def rf_multiusrp_data_transmitter(args):
     """
-    Run Tx waveform playback using MultiUSRP (B2xx devices)
+    Run Tx waveform playback using MultiUSRP
     """
 
     # Run mmwave devices first if exist
@@ -339,13 +340,12 @@ def rf_multiusrp_data_transmitter(args):
         run_mmWave_device.start_beamformer(mmwave_antenna_array_parameters)
 
     print("")
-    print("Using B2xx MultiUSRP TX Backend")
+    print("Using MultiUSRP TX Backend")
 
     # ************************************************************************
     # Create USRP
     # ************************************************************************
     print("Creating MultiUSRP with args:", args.args)
-
     usrp = uhd.usrp.MultiUSRP(args.args)
 
     # ************************************************************************
@@ -397,7 +397,6 @@ def rf_multiusrp_data_transmitter(args):
 
     print(f"Requesting TX Rate: {tx_rate / 1e6:.3f} Msps")
     usrp.set_tx_rate(tx_rate)
-
     print(f"Actual TX Rate: {usrp.get_tx_rate() / 1e6:.3f} Msps")
 
     print(f"Requesting TX Frequency: {args.freq / 1e6:.3f} MHz")
@@ -417,7 +416,6 @@ def rf_multiusrp_data_transmitter(args):
         pass
 
     print(f"Requesting TX Gain: {args.gain} dB")
-
     usrp.set_tx_gain(args.gain, args.radio_chan)
 
     try:
@@ -427,7 +425,6 @@ def rf_multiusrp_data_transmitter(args):
 
     try:
         usrp.set_tx_bandwidth(args.bandwidth, args.radio_chan)
-
         print(
             f"Actual TX Bandwidth: "
             f"{usrp.get_tx_bandwidth(args.radio_chan) / 1e6:.3f} MHz"
@@ -437,7 +434,6 @@ def rf_multiusrp_data_transmitter(args):
 
     try:
         usrp.set_tx_antenna(args.antenna, args.radio_chan)
-
         print(
             f"Actual TX Antenna: "
             f"{usrp.get_tx_antenna(args.radio_chan)}"
@@ -448,9 +444,9 @@ def rf_multiusrp_data_transmitter(args):
     # Allow for some setup time
     time.sleep(100e-3)
 
-    # ============================================================
-    # Repeat waveform to minimum 0.5s to avoid TX loop congestion
-    # ============================================================
+    # ************************************************************************
+    # Repeat waveform to a minimum of 0.5s to avoid TX loop congestion
+    # ************************************************************************
     target_duration_s = 0.5
     repetition = max(1, int(np.ceil(target_duration_s * tx_rate / len(tx_data_complex))))
     tx_data_complex = np.tile(tx_data_complex, repetition)

--- a/src/lib/run_rf_replay_data_transmitter.py
+++ b/src/lib/run_rf_replay_data_transmitter.py
@@ -448,10 +448,12 @@ def rf_multiusrp_data_transmitter(args):
     # Allow for some setup time
     time.sleep(100e-3)
 
-    # ************************************************************************
-    # Prepare waveform
-    # ************************************************************************
-    tx_data_complex = np.tile(tx_data_complex, 50)
+    # ============================================================
+    # Repeat waveform to minimum 0.5s to avoid TX loop congestion
+    # ============================================================
+    target_duration_s = 0.5
+    repetition = max(1, int(np.ceil(target_duration_s * tx_rate / len(tx_data_complex))))
+    tx_data_complex = np.tile(tx_data_complex, repetition)
 
     duration = len(tx_data_complex) / tx_rate
 

--- a/src/lib/run_rf_replay_data_transmitter.py
+++ b/src/lib/run_rf_replay_data_transmitter.py
@@ -449,7 +449,7 @@ def rf_multiusrp_data_transmitter(args):
     # ************************************************************************
     target_duration_s = 0.5
     repetition = max(1, int(np.ceil(target_duration_s * tx_rate / len(tx_data_complex))))
-    tx_data_complex = np.tile(tx_data_complex, repetition)
+    tx_data_complex = np.tile(tx_data_complex.astype(np.complex64), repetition)
 
     duration = len(tx_data_complex) / tx_rate
 

--- a/src/lib/run_rf_replay_data_transmitter.py
+++ b/src/lib/run_rf_replay_data_transmitter.py
@@ -37,9 +37,17 @@ def str2bool(v):
         return False
     else:
         raise argparse.ArgumentTypeError("Boolean value expected.")
-
-
+#siddhant_code_change
 def rf_replay_data_transmitter(args):
+    
+    print("HW TYPE =", args.hw_type)
+    if "B" in str(args.hw_type).upper():
+        return rf_b2xx_data_transmitter(args)
+    else:
+        return rf_replay_data_transmitter_rfnoc(args)
+
+#siddhant_code_change
+def rf_replay_data_transmitter_rfnoc(args):
     """
     Run Tx waveform playback
     """
@@ -315,3 +323,257 @@ def rf_replay_data_transmitter(args):
 
     print("Letting device settle...")
     time.sleep(0.05)  # sleep for 50ms
+
+#siddhant_code_change
+def rf_b2xx_data_transmitter(args):
+    """
+    Run Tx waveform playback using MultiUSRP (B2xx devices)
+    """
+
+    # ============================================================
+    # Run mmWave devices first if exist
+    # ============================================================
+    if args.enable_mmwave:
+        mmwave_up_down_converter_parameters = args.mmwave_up_down_converter_parameters
+        mmwave_antenna_array_parameters = args.mmwave_antenna_array_parameters
+        run_mmWave_device.start_ud_execution(
+            mmwave_up_down_converter_parameters
+        )
+        run_mmWave_device.start_beamformer(
+            mmwave_antenna_array_parameters
+        )
+
+    print("")
+    print("===================================")
+    print("Using B2xx MultiUSRP TX Backend")
+    print("===================================")
+
+    # ============================================================
+    # Create USRP
+    # ============================================================
+    print("Creating MultiUSRP with args:", args.args)
+
+    usrp = uhd.usrp.MultiUSRP(args.args)
+
+    # ============================================================
+    # Load waveform
+    # ============================================================
+    print("")
+    print("Reading waveform...")
+
+    tx_rate = args.rate
+
+    if args.waveform_format == "tdms":
+
+        tx_data_complex, waveform_IQ_rate = (
+            read_waveform_data_interface.read_waveform_data_tdms(
+                args.waveform_path,
+                args.waveform_file_name
+            )
+        )
+
+        tx_rate = waveform_IQ_rate
+
+        print(
+            f"TDMS IQ Rate : "
+            f"{tx_rate/1e6:.3f} Msps"
+        )
+
+    elif args.waveform_format == "matlab_ieee":
+
+        tx_data_complex = (
+            read_waveform_data_interface.read_waveform_data_matlab_ieee(
+                args.waveform_path,
+                args.waveform_file_name
+            )
+        )
+
+    elif args.waveform_format == "matlab":
+
+        tx_data_complex = (
+            read_waveform_data_interface.read_waveform_data_matlab(
+                args.waveform_path,
+                args.waveform_file_name
+            )
+        )
+
+    else:
+        raise Exception(
+            "ERROR: Unknown or not supported waveform format."
+        )
+
+    print("IQ Samples:", len(tx_data_complex))
+
+    # ============================================================
+    # Configure TX
+    # ============================================================
+    try:
+        usrp.set_clock_source(args.clock_reference)
+    except Exception:
+        pass
+
+    print(
+        f"Requesting TX Rate: "
+        f"{tx_rate/1e6:.3f} Msps"
+    )
+
+    usrp.set_tx_rate(tx_rate)
+
+    print(
+        f"Actual TX Rate: "
+        f"{usrp.get_tx_rate()/1e6:.3f} Msps"
+    )
+
+    print(
+        f"Requesting TX Frequency: "
+        f"{args.freq/1e6:.3f} MHz"
+    )
+
+    if str2bool(args.enable_lo_offset):
+
+        tune_request = uhd.types.TuneRequest(
+            args.freq,
+            args.lo_offset
+        )
+
+        usrp.set_tx_freq(
+            tune_request,
+            args.radio_chan
+        )
+
+    else:
+
+        usrp.set_tx_freq(
+            args.freq,
+            args.radio_chan
+        )
+
+    try:
+        print(
+            f"Actual TX Frequency: "
+            f"{usrp.get_tx_freq(args.radio_chan)/1e6:.3f} MHz"
+        )
+    except Exception:
+        pass
+
+    print(f"Requesting TX Gain: {args.gain} dB")
+
+    usrp.set_tx_gain(
+        args.gain,
+        args.radio_chan
+    )
+
+    try:
+        print(
+            f"Actual TX Gain: "
+            f"{usrp.get_tx_gain(args.radio_chan)} dB"
+        )
+    except Exception:
+        pass
+
+    try:
+
+        usrp.set_tx_bandwidth(
+            args.bandwidth,
+            args.radio_chan
+        )
+
+        print(
+            f"Actual TX Bandwidth: "
+            f"{usrp.get_tx_bandwidth(args.radio_chan)/1e6:.3f} MHz"
+        )
+
+    except Exception:
+        print("Bandwidth configuration skipped")
+
+    try:
+
+        usrp.set_tx_antenna(
+            args.antenna,
+            args.radio_chan
+        )
+
+        print(
+            f"Actual TX Antenna: "
+            f"{usrp.get_tx_antenna(args.radio_chan)}"
+        )
+
+    except Exception:
+        print("Antenna configuration skipped")
+
+    time.sleep(0.1)
+
+    # ============================================================
+    # Repeat waveform
+    # same idea as your standalone script
+    # ============================================================
+    tx_data_complex = np.tile(
+        tx_data_complex,
+        50
+    )
+
+    duration = len(tx_data_complex) / tx_rate
+
+    print("Repeated Samples:", len(tx_data_complex))
+    print("Waveform Duration:", duration)
+
+    tx_channels = [args.radio_chan]
+
+    # ============================================================
+    # Start RX acquisition
+    # ============================================================
+    sync_settings.start_rx_data_acquisition_called = True
+
+    print("")
+    print("Starting Continuous Transmission")
+
+    try:
+
+        first_run = True
+
+        while not sync_settings.stop_tx_signal_called:
+
+            if first_run:
+
+                tx_start_time = (
+                    usrp.get_time_now()
+                    + uhd.types.TimeSpec(0.2)
+                )
+
+                first_run = False
+
+            else:
+
+                tx_start_time = None
+
+            usrp.send_waveform(
+                tx_data_complex,
+                duration,
+                args.freq,
+                tx_rate,
+                tx_channels,
+                args.gain,
+                tx_start_time,
+            )
+
+    except Exception as ex:
+
+        print("TX Error:", ex)
+
+    print("Stopping transmission...")
+
+    # ============================================================
+    # mmWave cleanup
+    # ============================================================
+    if args.enable_mmwave:
+
+        run_mmWave_device.deinit_mmwave_device(
+            mmwave_up_down_converter_parameters.serial_number
+        )
+
+        run_mmWave_device.deinit_mmwave_device(
+            mmwave_antenna_array_parameters.serial_number
+        )
+
+    print("Letting device settle...")
+    time.sleep(0.05)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/ni-rf-data-recording-api/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Implements support for B2xx as transmitter using MultiUSRP instead for RFNoC replay block.

### Why should this Pull Request be merged?

Add general support for B2xx USRP as transmitter

### What testing has been done?

Tested on B210, B205mini and B206mini used as transmitter
